### PR TITLE
Encode wait and hook steps with go-yaml

### DIFF
--- a/tests/command.bats
+++ b/tests/command.bats
@@ -216,7 +216,7 @@ steps:
 - command:
   - echo one
   - echo two
-- wait
+- wait: null
 - command: echo "hello world"
 - command: cat ./foo-file.txt
 EOM


### PR DESCRIPTION
Fixes #106

I've tested on Buildkite that `- wait: null` is equivalent to `- wait: ~` and `- wait`.