### PR TITLE
Add support to pass build meta_data in trigger steps

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -88,11 +88,12 @@ type Agent map[string]string
 
 // Build is buildkite build definition
 type Build struct {
-	Message string            `yaml:"message,omitempty"`
-	Branch  string            `yaml:"branch,omitempty"`
-	Commit  string            `yaml:"commit,omitempty"`
-	RawEnv  interface{}       `json:"env" yaml:",omitempty"`
-	Env     map[string]string `yaml:"env,omitempty"`
+	Message  string            `yaml:"message,omitempty"`
+	Branch   string            `yaml:"branch,omitempty"`
+	Commit   string            `yaml:"commit,omitempty"`
+	RawEnv   interface{}       `json:"env" yaml:",omitempty"`
+	Env      map[string]string `yaml:"env,omitempty"`
+	MetaData map[string]string `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
 	// Notify  []Notify          `yaml:"notify,omitempty"`
 }
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -75,7 +75,10 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 					"config": {
 						"trigger": "service-2",
 						"build": {
-							"message": "some message"
+							"message": "some message",
+							"meta_data": {
+								"foo": "bar"
+							}
 						}
 					}
 				},
@@ -181,6 +184,9 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 							"env1": "env-1",
 							"env2": "env-2",
 							"env3": "env-3",
+						},
+						MetaData: map[string]string{
+							"foo": "bar",
 						},
 					},
 				},


### PR DESCRIPTION
# Synopsis

Buildkite [supports](https://buildkite.com/docs/pipelines/trigger-step#trigger-step-attributes) passing `meta_data` in trigger step. Looks like this functionality was missing. 

Resolves https://github.com/monebag/monorepo-diff-buildkite-plugin/issues/133