### PR TITLE
fix: Allow empty generated pipelines to be skipped

### DIFF
--- a/tests/command.bats
+++ b/tests/command.bats
@@ -298,3 +298,31 @@ steps:
 - command: cat ./foo-file.txt
 EOM
 }
+
+@test "Pipeline is generated as empty" {
+  DIFF_CMD="echo bar-service/"
+  LOG_LEVEL="debug"
+
+  export BUILDKITE_PLUGINS='[{
+    "github.com/monebag/monorepo-diff-buildkite-plugin": {
+      "diff":"echo bar-service/",
+      "log_level": "debug",
+      "watch": [
+        {
+          "path":"foo-service/",
+          "config": {
+            "trigger":"foo-service"
+          }
+        }
+      ]
+    }
+  }]'
+
+  run $PWD/hooks/command
+
+  assert_success
+
+  assert_output --partial << EOM
+steps: []
+EOM
+}


### PR DESCRIPTION
This PR fixes [issue](https://github.com/monebag/monorepo-diff-buildkite-plugin/issues/135). If a generated pipeline has no steps generated, whether from the watched paths or via aspects of the plugin ie hooks, it skips attempting to upload it. This is similar to the behaviour if there is no diff output.

In order to accomplish this, added a boolean to the output of generatePipeline() returning true if the generated pipeline has at least 1 step defined else returns false. This is then checked in uploadPipeline() and if the returned value was false ie there were no generated steps, uploadPipeline() returns without attempting to upload the empty pipeline.    